### PR TITLE
Progress on ETL

### DIFF
--- a/etl/RetrosheetParser.py
+++ b/etl/RetrosheetParser.py
@@ -1,0 +1,82 @@
+"""
+Parse Retrosheet Data
+
+Goal: turn data into relational tables
+? Use python schematics for data validation
+"""
+
+
+class RetrosheetLineParser()
+
+
+    def init(self):
+        parser_map = {
+                "id" : self.parse_id
+                , "version" : self.version
+                , "info": self.info
+                , "start": self.start
+                , "play": self.play
+                , "sub": self.sub
+                , "data": self.data
+                }
+
+
+    def type_parser(self, retro_list, parser_map):
+        "Read the type and pass to the appropriate parser"
+        retro_type = retro_list[0]
+        if parser_map.has_key(retro_type):
+            parser = self.parser_map[retro_type]
+            type_parsed = parser(retro_list)
+            return type_parsed
+        else:
+            # TODO: Replace with logger
+            print("Unknown retrosheet data type: %s. Skipping" % (retro_type))
+        return None 
+
+
+    def parse_id(self, retro_list):
+        "Parse the id type"
+        game_id = retro_list[1]
+        team = game_id[0:2]
+        year = game_id[3:6]
+        month = game_id[7:8]
+        day = game_id[9:10]
+        game_num = game_id[11]
+        id_instance = {
+                'game_id' : game_id
+                , 'team' : team
+                , 'year' : year
+                , 'month' : month
+                , 'day' : day
+                , 'game_num' : game_num
+                }
+        return id_instance
+
+    
+    def parse_version(self, retro_list):
+        "Parse the version type"
+        pass
+
+
+    def parse_info(self, retro_list):
+        pass
+
+
+    def parse_start(self, retro_list):
+        "Parse the start type"
+        pass
+
+
+    def parse_play(self, retro_list):
+        "Parse the play type"
+        pass
+
+
+    def parse_sub(self, retro_list):
+        "Parse the sub type"
+        pass
+
+
+    def parse_data(self, retro_list):
+        "Parse the retrodata 'data' type"
+        pass

--- a/etl/RetrosheetTableBuilder.py
+++ b/etl/RetrosheetTableBuilder.py
@@ -1,0 +1,104 @@
+"""
+Retrosheet Table Builder
+
+"""
+
+import os
+from os import listdir
+from os.path import isfile, join
+onlyfiles = [f for f in listdir(mypath) if isfile(join(mypath, f))]
+import sys
+
+import psycopg2
+
+from RetrosheetParser import RetrosheetLineParser
+
+
+class RetrosheetTableBuilder()
+
+
+    def init(self):
+        conn = psycopg2.connect(**db_credentials)
+        cur = conn.cursor()
+
+        GAME_INFO_TABLE = 'game_info'
+        PLAY_BY_PLAY_TABLE = 'play_by_play'
+        STARTERS_TABLE = 'starters'
+
+
+    def build_rts_tables(self, dir_path, tmp_dir):
+        """From a directory of retrosheet files, build relational tables"""
+        # Create tables
+        self.create_rts_tables()
+        # Loop through files
+        for element in listdir(dir_path):
+            if isfile(join(dir_path, element)) and \
+                element.lower().endswith(('.eva', '.evn')):
+                self.rts_line_parser(file_path, tmp_dir)
+                self.rts_db_update(tmp_dir)
+                self.clean_tmp_dir(tmp_dir)
+            else:
+                print('Unrecognized file: %s. Skipping' % (element))
+
+
+    def rts_line_parser(self, file_path, tmp_dir):
+        """From a retrosheet file, parse it into a relational table"""
+        pass
+
+
+    def rts_db_update(self, tmp_dir):
+        """Update the database from a set of temp files in relational format"""
+        pass
+
+    
+    def clean_tmp_dir(self, tmp_dir):
+        """Remove files from a tmp directory"""
+        pass
+
+
+    def create_rts_tables(self):
+        print("Create starters table")
+        self.cur.execute("""
+            CREATE TABLE starters (
+                game_id VARCHAR(12) NOT NULL
+                , rts_player_id VARCHAR(8) NOT NULL
+                , player_name VARCHAR(35)
+                , home_team BOOLEAN
+                , batting_order INTEGER
+                , field_position INTEGER
+                , PRIMARY KEY (game_id, rts_player_id)
+            );
+            """)
+        cur.commit()
+
+        print("Create play_by_play table")
+        self.cur.execute("""
+            CREATE TYPE play_type AS ENUM ('play', 'sub', 'badj', 'padj'
+                , 'ladj')
+
+            CREATE TABLE play_by_play (
+               game_id VARCHAR(12) NOT NULL
+               , rts_player_id VARCHAR(35) NOT NULL
+               , rts_play_sequence INTEGER
+               , play_type play_type 
+               , inning INTEGER
+               , home_team BOOLEAN
+               , batter_count VARCHAR(3)
+               , pitch_meta VARCHAR(15)
+               , play_meta VARCHAR(20)
+               , sub_batting_order INTEGER
+               , sub_field_position INTEGER
+               , PRIMARY KEY (game_id, rts_player_id, rts_play_sequence)
+            );
+        """)
+
+        print("Create game_info table")
+        self.cur.execute("""
+        """);
+
+
+
+
+if __name__ == "__main__":
+    """Parse cmd line args and build retrosheet tables"""
+    pass

--- a/etl/get_retrosheet_data.sh
+++ b/etl/get_retrosheet_data.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Extract RetroSheet Data
+
+ETL_LOG=etl.log
+retrosheet_dir=./retrosheet_data
+
+for year in $(seq 1980 1 1982)
+do
+    echo "Downloading year: ${year}"
+    wget http://www.retrosheet.org/events/${year}eve.zip -P $retrosheet_dir 2>&1 | tee -a $ETL_LOG
+    echo "Extracting year: ${year}" 
+    unzip ${retrosheet_dir}/${year}eve.zip -d $retrosheet_dir 2>&1 | tee -a $ETL_LOG
+    echo "Cleaning up: ${year}"
+    rm ${retrosheet_dir}/*.ROS
+    rm ${retrosheet_dir}/TEAM*
+    rm ${retrosheet_dir}/*.zip
+done

--- a/etl/retrosheet_notes.md
+++ b/etl/retrosheet_notes.md
@@ -1,0 +1,36 @@
+Retrosheet Data Structure
+-------------------------
+- first column indicates data type
+
+- "id" type breaks the csv into game sections
+- The "id" value is 3 letter team abbreviation (DET) YYYYMMDDX where I believe X is the game number of the day i.e. double headers
+
+- "version" type
+- integer (version number)
+
+- "info" type
+- the subsequent 2 keys are a key-value pair that should be treated as strings
+
+- "start" type
+- followed by: player id, name in quoted, integer, integer, integer
+
+- "play" and "sub" are mixed together, and appear sequential
+  - "play" type
+  - integer, integer, player id, string, string, string
+  - "sub" type
+  - player id, name, integer, integer, integer
+
+- "data" type
+- string, player id, integer
+
+Description (http://www.retrosheet.org/eventfile.htm)
+
+Base Tables
+- Starter table
+  - game_id (string), player id, name, integer, integer, integer
+
+- Play-by-play table
+  - game_id, player id, play sequence, play type (play or sub), ? flatten data 
+
+- Game Info table
+  - game_id (string), visiting team, hometeam, site, date, info (json) 


### PR DESCRIPTION
This adds a few files that work towards building a relational schema to improve usability of the data and allow a refactor of the monolithic BaseballExtract.py
- get_retrosheet_data.sh is a simple script to download an arbitrary number of years of retrosheet data
- RetrosheetParser.py is designed to handle the logic for individual lines of retrosheet data
- RetrosheetTableBuilder.py is set up to use the parser to transform the retrosheet data into relational tables using the parser
