### PR TITLE
Filled out rts table variables in RTB. Scattered Qs for JC

### DIFF
--- a/etl/RetrosheetParser.py
+++ b/etl/RetrosheetParser.py
@@ -14,11 +14,11 @@ class RetrosheetLineParser(object):
                 "id" : self.parse_id
                 , "version" : self.parse_version
                 , "info": self.parse_info
-                , "start": self.parse_start
+                , "start": self.parse_starter
                 , "play": self.parse_play 
                 , "sub": self.parse_sub
                 , "data": self.parse_data
-                , "com": self.com
+                , "com": self.parse_com
                 , "ladj": self.parse_ladj
                 , "badj": self.parse_badj
                 , "padj": self.parse_padj
@@ -27,7 +27,6 @@ class RetrosheetLineParser(object):
         info_types = ['visteam', 'hometeam', 'site', 'date', 'number', 'starttime', 'daynight', 'usedh', 'umphome', 'ump1b', 'ump2b', 'ump3b', 'howscored', 'pitches', 'temp', 'winddir', 'windspeed', 'fieldcond', 'precip', 'sky', 'timeofgame', 'attendance', 'wp', 'lp', 'save', 'gwrbi']
         
         play_types = tuple(['S', 'K', 'D', 'H', 'W', 'IW', 'T', 'E', 'FC', 'HP', 'C', 'NP'] + map(str,range(1,10)))
-
 
     def type_parser(self, retro_list, parser_map):
         "Read the type and pass to the appropriate parser"
@@ -40,7 +39,6 @@ class RetrosheetLineParser(object):
             # TODO: Replace with logger
             print("Unknown retrosheet data type: %s. Skipping" % (retro_type))
         return None 
-
 
     def parse_id(self, retro_list):
         "Parse the id type"
@@ -57,6 +55,7 @@ class RetrosheetLineParser(object):
                 , 'month' : month
                 , 'day' : day
                 , 'game_num' : game_num
+                , 'type': 'id_instance'
                 }
         return id_instance
         
@@ -79,21 +78,23 @@ class RetrosheetLineParser(object):
     	"Parse the info type"
     	# We don't need to read all "info" rows. For example, an "info" row repeats the game date, which is already collected from "id".  There are other random "info" types that are not particularly relevant. Perhaps it is better to trim those less relevant info lines later?
     	if retro_list[1] in self.info_types:
-	    	info_instance = {retro_list[1]: retro_list[2]}
+	    	info_instance = {
+	    		retro_list[1]: retro_list[2]
+	    		, 'type': 'info_instance'
+	    		}
 	    return info_instance
 
-
-    def parse_start(self, retro_list):
-        "Parse the start type"
+    def parse_starter(self, retro_list):
+        "Parse the starter type"
         player_instance = {
         		'player_id': retro_list[1]
         		, 'player_name': retro_list[2]
         		, 'player_team': retro_list[3]
         		, 'batting_order': retro_list[4]
         		, 'def_position': retro_list[5]
+        		, 'type': 'starter_instance'
         		}
-        return player_instance
-
+        return starter_instance
 
     def parse_play(self, retro_list):
         "Parse the play type"
@@ -106,8 +107,10 @@ class RetrosheetLineParser(object):
         			, 'count': retro_list[4]
         			, 'pitch_seq': retro_list[5]
         			, 'play_event': retro_list[6]
+        			, 'type': 'play_instance'
         			}
-        	return play_instance
+        
+        return play_instance
 
     def parse_sub(self, retro_list):
         "Parse the sub type"
@@ -118,6 +121,7 @@ class RetrosheetLineParser(object):
         		, 'player_team': retro_list[3]
         		, 'batting_order': retro_list[4]
         		, 'def_position': retro_list[5]
+        		, 'type': 'sub_instance'
         		}
         return sub_instance
 
@@ -126,7 +130,13 @@ class RetrosheetLineParser(object):
         data_instance = {
         		'player_id': retro_list[2]
         		, 'earned_runs': retro_list[3]
+        		, 'type': 'data_instance'
         		}
+        return data_instance
+    
+    def parse_com(self, retro_list):
+    	"Parse the com type"
+    	pass
     
     def parse_ladj(self, retro_list):
     	"Parse the ladj type"
@@ -134,18 +144,24 @@ class RetrosheetLineParser(object):
     	ladj_instance = {
     			'team': retro_list[1]
     			, 'batting_order': retro_list[2]
+    			, 'type': 'ladj_instance'
+    			}
+    	return ladj_instance
     
     def parse_badj(self, retro_list):
     	"Parse the badj type"
     	badj_instance = {
     			'player_id': retro_list[1]
     			, 'badj_note': retro_list[2]
+    			, 'type': 'badj_instance'
     			}
+    	return badj_instance
     
     def parse_padj(self, retro_list):
     	"Parse the padj type"
     	padj_instance = {
     			'player_id': retro_list[1]
     			, 'padj_note': retro_list[2]
+    			, 'type': 'padj_instance'
     			}
-    	
+    	return padj_instance

--- a/etl/RetrosheetTableBuilder.py
+++ b/etl/RetrosheetTableBuilder.py
@@ -24,7 +24,8 @@ class RetrosheetTableBuilder(object):
         GAME_INFO_TABLE = 'game_info'
         PLAY_BY_PLAY_TABLE = 'play_by_play'
         STARTERS_TABLE = 'starters'
-
+        
+        rts_line_types = RetrosheetLineParser.parser_map.keys()
 
     def build_rts_tables(self, dir_path, tmp_dir):
         """From a directory of retrosheet files, build relational tables"""
@@ -35,24 +36,38 @@ class RetrosheetTableBuilder(object):
             if isfile(join(dir_path, element)) and \
                 element.lower().endswith(('.eva', '.evn')):
                 # file_path was not previously defined.
-                self.file_path = join(dir_path, element)
-                self.rts_line_parser(self.file_path, tmp_dir)
+                file_path = join(dir_path, element)
+                self.rts_line_parser(file_path, tmp_dir)
                 self.rts_db_update(tmp_dir)
                 self.clean_tmp_dir(tmp_dir)
             else:
                 print('Unrecognized file: %s. Skipping' % (element))
 
-
     def rts_line_parser(self, file_path, tmp_dir):
         """From a retrosheet file, parse it into a relational table"""
-#         a = RetrosheetLineParser()
-#         with open(self.file_path,'r') as f:
+
+## My line of thinking with what is below is that the code needs to create a dictionary in the python environment that will be saved (temporarily) as a .csv (probably) and ultimately moved to a remote relational table (postgres).  Therefore, I think step 1 is creating dictionaries with keys corresponding to the variable names that will ultimately be stored in the relational tables. At least that's my line of thinking.
+
+#         temp_game_info = dict.fromkeys([
+#         		'game_id' , 'vistteam', 'hometeam', 'site', 'date', 'number', 'starttime', 'day_night', 'dh', 'umphome', 'ump1b', 'ump2b', 'ump3b', 'pitches', 'temp', 'winddir', 'windspeed', 'fieldcond', 'precip', 'sky', 'time_of_game', 'attendance', 'wp', 'lp', 'save', 'gwrbi', 'prim_key'
+#         		])
+#         
+#         temp_pbp = dict.fromkeys([
+#         		'game_id', 'rts_player_id', 'rts_play_sequence', 'player_team', 'play_type', 'inning', 'bottom_inning', 'home_team', 'rts_pitch_count', 'rts_pitch_seq', 'play_meta', 'sub_batting_order', 'sub_field_position', 'prim_key'
+#         		])
+#                
+#         temp_starters = dict.fromkeys([
+#                 'game_id', 'rts_player_id', 'player_name', 'player_team', 'home_team', 'batting_order', 'field_position', 'prim_key'
+#                 ])
+
+## I am a little in doubt about precisely how to structure this.  For example, we need to know what type of instance is returned for each line in order to know what to do with it, right?
+
+#         with open(file_path,'r') as f:
 #         	for line in f:
-#         		line_parts = line.split(',')
-#         		a.type_parser(line_parts, a.parser_map)
+#         		morsel = RetrosheetLineParser.type_parser(line,
+#         			RetrosheetLineParser.parser_map)        
 	    pass
-
-
+	
     def rts_db_update(self, tmp_dir):
         """Update the database from a set of temp files in relational format"""
         pass
@@ -121,7 +136,6 @@ class RetrosheetTableBuilder(object):
         		, site VARCHAR(5)
         		, date DATE
         		, number INTEGER
-        		# start_time
         		, day_night BOOLEAN
         		, dh BOOLEAN
         		, umphome VARCHAR(8)
@@ -129,7 +143,7 @@ class RetrosheetTableBuilder(object):
         		, ump2b VARCHAR(8)
         		, ump3b VARCHAR(8)
         		, pitches pitches_type
-        		, starttime
+        		, starttime time
         		, temp INTEGER
         		, winddir winddir_type
         		, windspeed INTEGER


### PR DESCRIPTION
I created a "type" key for the "type_instance" variables that are returned from the many fx in RetrosheetParser (RP).  My thinking is that RetrosheetTableBuilder (RTB) will need to know what type of instance is being returned each time it is receives a newly parsed line.

I have some comments distributed throughout that were intended as questions for you.  I now see your e-mail and I think I understand more clearly why that is a bad idea.  I'll move those into these comment forums in the future.  There is good practice in this collaborative coding that I am learning as we go along.  Sorry for that pain in your ass.
